### PR TITLE
Rebuild for python 3.11

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+# Not on aggregate because it is deprecated
+aggregate_check: false

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,9 +9,9 @@ source:
   sha256: 3e8c868046f56dea84c949cc7e97383cccfab27152fc3f4968754e4c9c087ab9
 
 build:
-  number: 0
+  number: 1
   skip: True  # [py<36]
-  script: {{ PYTHON }} -m pip install . -vv --no-deps
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
   host:


### PR DESCRIPTION
Rebuilding for python 3.11. Required to also rebuild gymnasium 0.26.3 for Python 3.11.

Channel: Defaults